### PR TITLE
Fix ingress for file size and session stickiness

### DIFF
--- a/ingress.yaml
+++ b/ingress.yaml
@@ -3,6 +3,11 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod-dns
+    nginx.ingress.kubernetes.io/proxy-body-size: 200m
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-name: "http-cookie"
+    nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
+    nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
   name: ingress-linkedin-games-ranking
   namespace: default
 spec:


### PR DESCRIPTION
Annotated ingress to keep session sticky (fixes file upload) and to allow file size up to 200 MB